### PR TITLE
Wait for REG_CPURESET to read zero before calling getspace() in init

### DIFF
--- a/circuitPython/lib/brteve/brt_eve_module.py
+++ b/circuitPython/lib/brteve/brt_eve_module.py
@@ -77,9 +77,14 @@ class BrtEveModule(BrtEveCommon, BrtEveMoviePlayer): # pylint: disable=too-many-
         self.eve.register(self)
         self.coldstart()
 
+        # Programming Guide 2.4: Initialization Sequence during Boot Up
         time_start = time.monotonic()
         while self.rd32(self.eve.REG_ID) != 0x7c:
             assert (time.monotonic() - time_start) < 1.0, "No response - is device attached?"
+
+        time_start = time.monotonic()
+        while self.rd16(self.eve.REG_CPURESET) != 0x0:
+            assert(time.monotonic() - time_start) < 1.0, "EVE engines failed to reset"
 
         self.getspace()
 


### PR DESCRIPTION
Based on #24. The initialization routine should wait for EVE engines to come out of reset before accessing other registers. This check along doesn't solve the issue but I chose to leave the arbitrary delay out of this PR since it's not fully understood.