### PR TITLE
- pad the input file to 4096 and fill with 0xff

### DIFF
--- a/tools/uf2/uf2conv4eve.py
+++ b/tools/uf2/uf2conv4eve.py
@@ -82,7 +82,7 @@ def convert_to_uf2(eve3_firmware, eve4_firmware, file_content):
     numblocks_eve3 = (len(eve3_firmware) + 255) // 256
     numblocks_eve4 = (len(eve4_firmware) + 255) // 256
     numblocks_fw = max(numblocks_eve3, numblocks_eve4)
-    numblocks_file = (((len(file_content)|4095)+1) - EVE_FLASH_FIRMWARE_SIZE + 255) // 256
+    numblocks_file = (((len(file_content)|4095)+1) - EVE_FLASH_FIRMWARE_SIZE) // 256
     if numblocks_file < (EVE_FLASH_FIRMWARE_SIZE // 256):
         numblocks_file = 0
     numblocks = numblocks_fw + numblocks_file

--- a/tools/uf2/uf2conv4eve.py
+++ b/tools/uf2/uf2conv4eve.py
@@ -82,7 +82,7 @@ def convert_to_uf2(eve3_firmware, eve4_firmware, file_content):
     numblocks_eve3 = (len(eve3_firmware) + 255) // 256
     numblocks_eve4 = (len(eve4_firmware) + 255) // 256
     numblocks_fw = max(numblocks_eve3, numblocks_eve4)
-    numblocks_file = (len(file_content) - EVE_FLASH_FIRMWARE_SIZE + 255) // 256
+    numblocks_file = (((len(file_content)|4095)+1) - EVE_FLASH_FIRMWARE_SIZE + 255) // 256
     if numblocks_file < (EVE_FLASH_FIRMWARE_SIZE // 256):
         numblocks_file = 0
     numblocks = numblocks_fw + numblocks_file
@@ -122,7 +122,7 @@ def convert_to_uf2(eve3_firmware, eve4_firmware, file_content):
             UF2_MAGIC_START0, UF2_MAGIC_START1,
             flags, ptr, 256, numblocks_fw + blockno, numblocks, 0)
         while len(chunk) < 256:
-            chunk += b"\x00"
+            chunk += b"\xff"
         block = hd + chunk + datapadding + struct.pack(b"<I", UF2_MAGIC_END)
         assert len(block) == 512
         outp.append(block)


### PR DESCRIPTION
See this discussion:
https://github.com/RudolphRiedel/FT800-FT813/discussions/88

Flashing from Pi-Pico is not working correctly.
EAB is not padding the flash image files to 4096 bytes.
uf2conv4eve.py / uf2conv4eve.exe is not padding the flash image files to 4096 bytes and fails if the .bin file is less than 8192 bytes.
eve_flash_pico.uf2 is not padding the .uf2 image to 4096 bytes but is using CMD_FLASHUPDATE

As I could not change EAB to use 4096 bytes padding and changing eve_flash_pico.uf2 would have been more complicated, I went for uf2conv4eve.py.
At least the resulting .uf2 files are generated with padding to 4096 bytes now.